### PR TITLE
[NO-JIRA] Add version to Creator:Tool field

### DIFF
--- a/build-sbom.py
+++ b/build-sbom.py
@@ -182,7 +182,7 @@ def main() -> int:
             name=CPYTHON_TARBALL_FILENAME,
             created=datetime.datetime.now(tz=datetime.timezone.utc),
             document_namespace=f"https://www.python.org/ftp/python/{CPYTHON_VERSION}/{CPYTHON_TARBALL_FILENAME}.spdx.json",
-            creators=[spdx.Actor(spdx.ActorType.TOOL, name="cpython-sbom")],
+            creators=[spdx.Actor(spdx.ActorType.TOOL, name="cpython-sbom-0.1.0")],
         )
     )
 


### PR DESCRIPTION
SPDX2.3 [specification](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#68-creator-field) expects Creator: Tool in the format

`toolidentifier-version`

Therefore, a strict read of the spec requires adding a version. The added tool version 0.1.0 is arbitrary for now.

Related: https://github.com/advanced-security/gh-sbom/issues/11