### PR TITLE
[NO-JIRA] Add suppliers and CPE for packages

### DIFF
--- a/build-sbom.py
+++ b/build-sbom.py
@@ -77,6 +77,7 @@ PACKAGES = [
         primary_package_purpose=spdx.PackagePurpose.SOURCE,
         download_url="https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz",
         download_hash_sha256="9f9cd4c041f99b5c49ffb7b59d9f12d95b683d88585608aa56a6307667b2b21f",
+        cpes=["cpe:2.3:a:bytereef:mpdecimal:2.5.1:*:*:*:*:*:*:*"],
         files_include=["Modules/_decimal/libmpdec/"],
         files_include_hashes=[
             "f86d26a0ada3a757f599453a8f86b46ee29073b85dd228783632aacc00ab9e50"
@@ -91,6 +92,7 @@ PACKAGES = [
         primary_package_purpose=spdx.PackagePurpose.SOURCE,
         download_url="https://github.com/mjosaarinen/tiny_sha3/archive/dcbb3192047c2a721f5f851db591871d428036a9.zip",
         download_hash_sha256="9b43effc6c8e234af84fd2367f831a697248191c8fa35c4441bb222924d2836a",
+        cpes=["cpe:2.3:a:mjosaarinen:tiny_sha3:dcbb3192047c2a721f5f851db591871d428036a9:*:*:*:*:*:*:*"],
         files_include=["Modules/_sha3/"],
         files_exclude=[
             "Modules/_sha3/clinic/",
@@ -183,6 +185,7 @@ PACKAGES = [
         license="CC0-1.0",
         license_evidence=NOASSERTION,
         primary_package_purpose=spdx.PackagePurpose.SOURCE,
+        cpes=["cpe:2.3:a:blake2:libb2:0.98.1:*:*:*:*:*:*:*"],
         files_include=["Modules/_blake2/impl/"],
         files_include_hashes=[
             "8e7205846d00022f568480d9ed6ddc5d3de47cc5a658ca04747a3eb8003fa498"

--- a/build-sbom.py
+++ b/build-sbom.py
@@ -31,6 +31,7 @@ class Package:
     download_hash_sha256: str | None = None
     cpes: list[str] = None
     purl: str | None = None
+    supplier: spdx.Actor | None = None
 
     @property
     def spdx_id(self) -> str:
@@ -66,6 +67,7 @@ PACKAGES = [
         download_hash_sha256="64424e96e2457abbac899b90f9530985b51eef2905951febd935f0e73414caeb",
         cpes=[f"cpe:2.3:a:python:python:{CPYTHON_VERSION}:*:*:*:*:*:*:*"],
         files_include=[],
+        supplier=spdx.Actor(spdx.ActorType.ORGANIZATION, name="Python Software Foundation"),
     ),
     Package(
         name="mpdecimal",
@@ -79,6 +81,7 @@ PACKAGES = [
         files_include_hashes=[
             "f86d26a0ada3a757f599453a8f86b46ee29073b85dd228783632aacc00ab9e50"
         ],
+        supplier=spdx.Actor(spdx.ActorType.ORGANIZATION, name="bytereef.org"),
     ),
     Package(
         name="tiny_sha3",
@@ -96,6 +99,7 @@ PACKAGES = [
         files_include_hashes=[
             "9dae1929a47e74039273a530580c8fea2404922f9b34de42eb4dd2f69397b34b"
         ],
+        supplier=spdx.Actor(spdx.ActorType.PERSON, name="Markku-Juhani O. Saarinen", email="mjos@iki.fi"),
     ),
     Package(
         name="expat",
@@ -110,6 +114,7 @@ PACKAGES = [
         files_include_hashes=[
             "1ce1444111271cc11d71b72c376a17447cf3d3b7dd61a0a01456d2e06faf22e9"
         ],
+        supplier=spdx.Actor(spdx.ActorType.ORGANIZATION, name="Expat development team"),
     ),
     Package(
         name="macholib",
@@ -124,6 +129,7 @@ PACKAGES = [
         files_include_hashes=[
             "59aa1f3194df7ebe23b0a821cb502b112032fc2e91470a04585d04c2ee63b3b5"
         ],
+        supplier=spdx.Actor(spdx.ActorType.PERSON, name="Ronald Oussoren", email="ronaldoussoren@mac.com"),
     ),
     Package(
         name="libffi",
@@ -137,6 +143,7 @@ PACKAGES = [
         files_include_hashes=[
             "2720798b5a98d9b5c8a4d88144670b8c63f3ae92ef26491661350720094f5833"
         ],
+        supplier=spdx.Actor(spdx.ActorType.PERSON, name="Ronald Oussoren", email="ronaldoussoren@mac.com"),
     ),
     Package(
         name="pip",
@@ -151,6 +158,7 @@ PACKAGES = [
         files_include_hashes=[
             "e3d26a8c958c7b53a243a24913fded4d4e7000dcf58a628d1d9c35111713c1a1"
         ],
+        supplier=spdx.Actor(spdx.ActorType.ORGANIZATION, name="Python Packaging Authority")
     ),
     Package(
         name="setuptools",
@@ -165,6 +173,7 @@ PACKAGES = [
         files_include_hashes=[
             "fe039e3aa4ac3550aa63c80b2ee9af608bb6b53abed32fc5ec3bca1b859694c0"
         ],
+        supplier=spdx.Actor(spdx.ActorType.ORGANIZATION, name="Python Packaging Authority")
     ),
     Package(
         name="libb2",
@@ -178,6 +187,7 @@ PACKAGES = [
         files_include_hashes=[
             "8e7205846d00022f568480d9ed6ddc5d3de47cc5a658ca04747a3eb8003fa498"
         ],
+        supplier=spdx.Actor(spdx.ActorType.ORGANIZATION, name="BLAKE2 — fast secure hashing")
     ),
 ]
 PACKAGES[1:] = sorted(PACKAGES[1:], key=lambda pkg: pkg.name)
@@ -225,6 +235,7 @@ def package_to_spdx_package(package: Package) -> spdx.Package:
         license_concluded=spdx_license.spdx_licensing.parse(package.license),
         external_references=external_references,
         primary_package_purpose=package.primary_package_purpose,
+        supplier=package.supplier
     )
 
 

--- a/build-sbom.py
+++ b/build-sbom.py
@@ -182,7 +182,7 @@ def main() -> int:
             name=CPYTHON_TARBALL_FILENAME,
             created=datetime.datetime.now(tz=datetime.timezone.utc),
             document_namespace=f"https://www.python.org/ftp/python/{CPYTHON_VERSION}/{CPYTHON_TARBALL_FILENAME}.spdx.json",
-            creators=[spdx.Actor(spdx.ActorType.TOOL, name="cpython-sbom")],
+            creators=[spdx.Actor(spdx.ActorType.TOOL, name="cpython-sbom-0.1.0")],
         )
     )
 


### PR DESCRIPTION
[NO-JIRA] Add CPE for packages

1. blake2 is known as a vendor in CPE
2. tiny_sha3 follows a typically seen pattern of org-name:repo-name at github
3. mpdecimal is a wildcard as no previously registered CPE for bytereef or mpdecimal


[NO-JIRA] Add known suppliers for packages

Supplier is an NTIA Minimum Elements recommendation. For open-source, it is recommended to include the name of the organization supporting or person managing the project to be included as a supplier.